### PR TITLE
【No.007】組織の管理画面と組織へのログイン処理

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -1,0 +1,2 @@
+class OrgsController < ApplicationController
+end

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -1,2 +1,15 @@
 class OrgsController < ApplicationController
+  before_action :set_org, only: %i[show]
+  def index
+    @orgs = Org.all
+  end
+
+  def show
+  end
+
+  private
+  def set_org
+    @org = Org.find(params[:id])
+  end
 end
+

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -1,0 +1,2 @@
+class Org < ApplicationRecord
+end

--- a/app/views/orders/ordering_org_sides/index.html.slim
+++ b/app/views/orders/ordering_org_sides/index.html.slim
@@ -1,53 +1,85 @@
-.py-5
-  .-my-2.overflow-x-auto(class="sm:-mx-6 lg:-mx-8")
-  .py-2.align-middle.inline-block.min-w-full(class="sm:px-6 lg:px-8")
-    .shadow.overflow-hidden.border-b.border-gray-200(class="sm:rounded-lg")
-      table.min-w-full.divide-y.divide-gray-200
-        thead
-          tr
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 注文No
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 商品画像
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 販売元ページ
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 買付先ページ
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 色・サイズ等
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 数量
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | お届け先
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 買付費用
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | ステータス
-            th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
-              | 編集
-        tbody.bg-white.divide-y.divide-gray-200
-          - @orders.each do |order|
-            tr
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                = order.trade_no
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                | 商品画像
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                a.text-indigo-600.hover:text-indigo-900 href="#"  販売元ページ
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                a.text-indigo-600.hover:text-indigo-900 href="#"  買付先ページ
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                = order.color_size
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                = order.quantity
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                | 〒#{order.postal}
-                br
-                = order.address
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                | $100
-              td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
-                = order.status_i18n
-              td.px-6.py-4.whitespace-no-wrap.text-right.text-sm.leading-5.font-medium
-                a.text-indigo-600.hover:text-indigo-900 href="#"
-                  i.fas.fa-edit
+.bg-gray-100
+  nav.bg-white.shadow-sm
+    .max-w-7xl.mx-auto.px-4.sm:px-6.lg:px-8
+      .flex.justify-between.h-16
+        .flex
+          .flex-shrink-0.flex.items-center
+          .hidden.sm:ml-6.space-x-8.sm:flex
+            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-indigo-500.text-sm.font-medium.leading-5.text-gray-900.focus:outline-none.focus:border-indigo-700.transition.duration-150.ease-in-out[href="#"]
+              | Sample_1
+            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
+              | Sample_2
+            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
+              | Sample_3
+            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
+              | Sample_4
+        .hidden.sm:ml-6.sm:flex.sm:items-center
+          button.p-1.border-2.border-transparent.text-gray-400.rounded-full.hover:text-gray-500.focus:outline-none.focus:text-gray-500.focus:bg-gray-100.transition.duration-150.ease-in-out[aria-label="Notifications"]
+            svg.h-6.w-6[stroke="currentColor" fill="none" viewbox="0 0 24 24"]
+              path[stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"]
+          .ml-3.relative
+            div
+              button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out[aria-label="User menu" aria-haspopup="true"]
+                i.fas.fa-user-circle.fa-2x.text-gray-700
+            .origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
+              .py-1.rounded-md.bg-white.shadow-xs
+                = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
+                  | 会社切替
+                / TODO:リンクを@orgに書き換える
+                = link_to '/', class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
+                  | 会社詳細
+  .py-10
+    .max-w-7xl.mx-auto.sm:px-6.lg:px-8
+      .py-5
+        .-my-2.overflow-x-auto(class="sm:-mx-6 lg:-mx-8")
+        .py-2.align-middle.inline-block.min-w-full(class="sm:px-6 lg:px-8")
+          .shadow.overflow-hidden.border-b.border-gray-200(class="sm:rounded-lg")
+            table.min-w-full.divide-y.divide-gray-200
+              thead
+                tr
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 注文No
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 商品画像
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 販売元ページ
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 買付先ページ
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 色・サイズ等
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 数量
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | お届け先
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 買付費用
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | ステータス
+                  th.px-6.py-3.bg-gray-200.text-left.text-xs.leading-4.font-medium.text-gray-500.uppercase.tracking-wider
+                    | 編集
+              tbody.bg-white.divide-y.divide-gray-200
+                - @orders.each do |order|
+                  tr
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      = order.trade_no
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      | 商品画像
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      a.text-indigo-600.hover:text-indigo-900 href="#"  販売元ページ
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      a.text-indigo-600.hover:text-indigo-900 href="#"  買付先ページ
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      = order.color_size
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      = order.quantity
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      | 〒#{order.postal}
+                      br
+                      = order.address
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      | $100
+                    td.px-6.py-4.whitespace-no-wrap.text-sm.leading-5.text-gray-500
+                      = order.status_i18n
+                    td.px-6.py-4.whitespace-no-wrap.text-right.text-sm.leading-5.font-medium
+                      a.text-indigo-600.hover:text-indigo-900 href="#"
+                        i.fas.fa-edit

--- a/app/views/orgs/index.html.slim
+++ b/app/views/orgs/index.html.slim
@@ -1,0 +1,15 @@
+.bg-white.shadow.m-auto.sm:rounded-md.mt-5(class="w-2/4")
+  ul
+    - @orgs.each do |org|
+      / TODO:Sassで場合分けできるようにする
+      - border_t = org == @orgs.first ? '' : 'border-t border-gray-200'
+      li.(class=border_t)
+        = link_to [org], class: 'block hover:bg-gray-50 focus:outline-none focus:bg-gray-50 transition duration-150 ease-in-out' do
+          .flex.items-center.px-4.py-4.sm:px-6
+            .min-w-0.flex-1.flex.items-center
+              .min-w-0.flex-1.px-4.md:grid.md:grid-cols-2.md:gap-4
+                div
+                  .text-sm.leading-5.font-medium.text-indigo-600.truncate
+                    = org.name
+              div
+                i.fas.fa-sign-in-alt.fa-lg.bg-gray-50.text-gray-500

--- a/app/views/orgs/show.html.slim
+++ b/app/views/orgs/show.html.slim
@@ -1,0 +1,18 @@
+.bg-white.shadow.m-auto.mt-5.overflow-hidden.sm:rounded-lg(class="w-1/2")
+  .px-4.py-5.border-b.border-gray-200.sm:px-6
+    h3.text-lg.leading-6.font-medium.text-gray-900
+      |  会社詳細
+    p.mt-1.max-w-2xl.text-sm.leading-5.text-gray-500
+      |  会社詳細を説明します。
+  div
+    dl
+      .bg-gray-100.px-4.py-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
+        dt.text-sm.leading-5.font-medium.text-gray-500
+          |  会社名
+        dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
+          = @org.name
+      .bg-white.px-4.py-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
+        dt.text-sm.leading-5.font-medium.text-gray-500
+          |  会社タイプ
+        dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
+          = @org.org_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root 'orders/ordering_org_sides#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resource :orgs, only: %i[index]
+  resources :orgs, only: %i[index show]
   namespace :orders do
-    resources :ordering_org_sides, only: %i[index, show]
+    resources :ordering_org_sides, only: %i[index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'orders/ordering_org_sides#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resource :orgs, only: %i[index]
   namespace :orders do
     resources :ordering_org_sides, only: %i[index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resource :orgs, only: %i[index]
   namespace :orders do
-    resources :ordering_org_sides, only: %i[index]
+    resources :ordering_org_sides, only: %i[index, show]
   end
 end

--- a/db/migrate/20201005000653_create_orgs.rb
+++ b/db/migrate/20201005000653_create_orgs.rb
@@ -1,0 +1,10 @@
+class CreateOrgs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orgs do |t|
+      t.string :name
+      t.integer :org_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_131116) do
+ActiveRecord::Schema.define(version: 2020_10_05_000653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,13 @@ ActiveRecord::Schema.define(version: 2020_09_22_131116) do
     t.string "color_size"
     t.integer "quantity"
     t.integer "status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "orgs", force: :cascade do |t|
+    t.string "name"
+    t.integer "org_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,3 +23,11 @@ orders = Order.create(
     {trade_no: '79330602', title: '◯◯◯◯◯◯◯◯◯◯', postal: 'XXX-XXXX', address: '◯◯県◯◯市◯◯区◯丁目◯◯-◯◯', name: 'YYYYYY', phone: 'XXX-XXXX-XXXX', color_size: '△△△', quantity: 1, status: 1},
   ]
 )
+
+orgs = Org.create(
+  [
+    {name: '会社_a', org_type: 0},
+    {name: '会社_b', org_type: 1},
+    {name: '会社_c', org_type: 0}
+  ]
+)

--- a/test/fixtures/orgs.yml
+++ b/test/fixtures/orgs.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  org_type: 1
+
+two:
+  name: MyString
+  org_type: 1

--- a/test/models/org_test.rb
+++ b/test/models/org_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OrgTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Issue #18 
参考 #16 

 # 概要
組織の管理画面と組織へのログイン処理を追加する

# ToDo詳細
- Orgモデル・テーブル追加

```Terminal:Terminal
bin/rails g model org name:string org_type:integer
```
- orgs_controllerを追加

```Terminal:Terminal
bin/rails g controller orgs
```

要らないファイルは削除しておく

```Terminal:Terminal
-> % bin/rails g controller orgs
Running via Spring preloader in process 22619
      create  app/controllers/orgs_controller.rb
      invoke  slim
      create    app/views/orgs
      invoke  test_unit
      create    test/controllers/orgs_controller_test.rb <- これ消した
      invoke  helper
      create    app/helpers/orgs_helper.rb <- これ消した
      invoke    test_unit
      invoke  assets
      invoke    coffee
      invoke    scss
      create      app/assets/stylesheets/orgs.scss <- これ消した
```

- orgs#indexのrouteを設定し、ビュー追加

```ruby:config/routes.rb
Rails.application.routes.draw do
  root 'orders/ordering_org_sides#index'
  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
  resource :orgs, only: %i[index] #<-追加
  namespace :orders do
    resources :ordering_org_sides, only: %i[index]
  end
end
```

```Terminal:Terminal
touch app/views/orgs/index.html.slim
```

```slim:app/views/orgs/index.html.slim
.bg-white.shadow.m-auto.sm:rounded-md.mt-5(class="w-2/4")
  ul
    - @orgs.each do |org|
      / TODO:Sassで場合分けできるようにする
      - border_t = org == @orgs.first ? '' : 'border-t border-gray-200'
      li.(class=border_t)
        = link_to [org], class: 'block hover:bg-gray-50 focus:outline-none focus:bg-gray-50 transition duration-150 ease-in-out' do
          .flex.items-center.px-4.py-4.sm:px-6
            .min-w-0.flex-1.flex.items-center
              .min-w-0.flex-1.px-4.md:grid.md:grid-cols-2.md:gap-4
                div
                  .text-sm.leading-5.font-medium.text-indigo-600.truncate
                    = org.name
              div
                i.fas.fa-sign-in-alt.fa-lg.bg-gray-50.text-gray-500
```

- orgs#sohwのrouteを設定し、ビュー追加

```ruby:config/routes.rb
Rails.application.routes.draw do
  root 'orders/ordering_org_sides#index'
  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
  resource :orgs, only: %i[index, show] #<-showも追加
  namespace :orders do
    resources :ordering_org_sides, only: %i[index]
  end
end
```

```Terminal:Terminal
touch app/views/orgs/show.html.slim
```

```slim:app/views/orgs/show.html.slim
.bg-white.shadow.m-auto.mt-5.overflow-hidden.sm:rounded-lg(class="w-1/2")
  .px-4.py-5.border-b.border-gray-200.sm:px-6
    h3.text-lg.leading-6.font-medium.text-gray-900
      |  会社詳細
    p.mt-1.max-w-2xl.text-sm.leading-5.text-gray-500
      |  会社詳細を説明します。
  div
    dl
      .bg-gray-100.px-4.py-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
        dt.text-sm.leading-5.font-medium.text-gray-500
          |  会社名
        dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
          = @org.name
      .bg-white.px-4.py-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
        dt.text-sm.leading-5.font-medium.text-gray-500
          |  会社タイプ
        dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
          = @org.org_type
```

- 右斜上にそれぞれの導線・リンクを配置

```slim:app/views/orders/ordering_org_sides/index.html.slim
.bg-gray-100
  nav.bg-white.shadow-sm
    .max-w-7xl.mx-auto.px-4.sm:px-6.lg:px-8
      .flex.justify-between.h-16
        .flex
          .flex-shrink-0.flex.items-center
          .hidden.sm:ml-6.space-x-8.sm:flex
            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-indigo-500.text-sm.font-medium.leading-5.text-gray-900.focus:outline-none.focus:border-indigo-700.transition.duration-150.ease-in-out[href="#"]
              | Sample_1
            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
              | Sample_2
            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
              | Sample_3
            a.inline-flex.items-center.px-1.pt-1.border-b-2.border-transparent.text-sm.font-medium.leading-5.text-gray-500.hover:text-gray-700.hover:border-gray-300.focus:outline-none.focus:text-gray-700.focus:border-gray-300.transition.duration-150.ease-in-out[href="#"]
              | Sample_4
        .hidden.sm:ml-6.sm:flex.sm:items-center
          button.p-1.border-2.border-transparent.text-gray-400.rounded-full.hover:text-gray-500.focus:outline-none.focus:text-gray-500.focus:bg-gray-100.transition.duration-150.ease-in-out[aria-label="Notifications"]
            svg.h-6.w-6[stroke="currentColor" fill="none" viewbox="0 0 24 24"]
              path[stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"]
          .ml-3.relative
            div
              button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out[aria-label="User menu" aria-haspopup="true"]
                i.fas.fa-user-circle.fa-2x.text-gray-700
            .origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
              .py-1.rounded-md.bg-white.shadow-xs
                = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
                  | 会社切替
                / TODO:リンクを@orgに書き換える
                = link_to '/', class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
                  | 会社詳細
```

![image](https://user-images.githubusercontent.com/45095615/95090075-d4e50b00-075f-11eb-931c-ecb55f18e175.png)

JSは別PRで対応予定。

- seedにorgsを追加

```ruby:db/seeds.rb
orgs = Org.create(
  [
    {name: '会社_a', org_type: 0},
    {name: '会社_b', org_type: 1},
    {name: '会社_c', org_type: 0}
  ]
)
```

# 動作確認
## 準備

```
bin/rails db:migrate:reset
bin/rails db:reset
```

## 受入基準
- [x] 下図のように画面遷移する

![85553aaf9b9e864a3642ee1dda1b55c4](https://user-images.githubusercontent.com/45095615/95091091-fabedf80-0760-11eb-86d7-8ae11fa7ed0e.gif)
