### PR TITLE
【No.011】会社の管理画面で注文一覧のリンクを作る

### DIFF
--- a/app/views/orgs/show.html.slim
+++ b/app/views/orgs/show.html.slim
@@ -23,4 +23,9 @@
         | オーナー
       dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
         | 山田太郎
-
+    .mt-8.sm:mt-0.sm:grid.sm:grid-cols-3.sm:gap-4.sm:border-t.sm:border-gray-200.sm:px-6.sm:py-5
+      dt.text-sm.leading-5.font-medium.text-gray-500
+        | 注文一覧
+      dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
+        = link_to orders_ordering_org_sides_path, class: 'text-sm font-medium text-indigo-600 truncate hover:text-indigo-400' do
+          | 注文一覧


### PR DESCRIPTION
# 概要
会社詳細画面から注文一覧画面への導線が分かりづらかったので、リストの中にリンクを追加する。

|![image](https://user-images.githubusercontent.com/45095615/103391757-592c0c00-4b5e-11eb-8b52-759d097abb04.png)|
|:--|

# ToDoリスト
- 会社詳細のリストの最終行に、注文一覧画面のリンクを追加する

|![image](https://user-images.githubusercontent.com/45095615/103391930-e8392400-4b5e-11eb-8d6c-03cc0c1133d3.png)|
|:--|

# ToDoリスト詳細
- 会社詳細のリストの最終行に注文一覧画面のリンクを追加する
```
.mt-8.sm:mt-0.sm:grid.sm:grid-cols-3.sm:gap-4.sm:border-t.sm:border-gray-200.sm:px-6.sm:py-5
  dt.text-sm.leading-5.font-medium.text-gray-500
    | 注文一覧
  dd.mt-1.text-sm.leading-5.text-gray-900.sm:mt-0.sm:col-span-2
    = link_to orders_ordering_org_sides_path, class: 'text-sm font-medium text-indigo-600 truncate hover:text-indigo-400' do
      | 注文一覧
```

# 動作確認
## 受入基準
- [ ] 会社詳細のリストの最終行に注文一覧画面のリンクが追加されている

|![image](https://user-images.githubusercontent.com/45095615/103392106-a0ff6300-4b5f-11eb-9ea4-16913ab77cad.png)|
|:--|
