### PR TITLE
【No.012】ドロップダウンをJSで実装

### DIFF
--- a/app/components/layout/navbar_component.html.slim
+++ b/app/components/layout/navbar_component.html.slim
@@ -18,7 +18,7 @@ nav.bg-white.shadow-sm
           svg.h-6.w-6[stroke="currentColor" fill="none" viewbox="0 0 24 24"]
             path[stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"]
         .ml-3.relative
-          button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
+          button.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
             type="button"
             class="group h-full flex items-center px-4 text-left focus:outline-none focus:rounded-md"
             data-dropdown="navbar-dropdown"

--- a/app/components/layout/navbar_component.html.slim
+++ b/app/components/layout/navbar_component.html.slim
@@ -18,18 +18,17 @@ nav.bg-white.shadow-sm
           svg.h-6.w-6[stroke="currentColor" fill="none" viewbox="0 0 24 24"]
             path[stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"]
         .ml-3.relative
-          div
-            button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
-              type="button"
-              class="group h-full flex items-center px-4 text-left focus:outline-none focus:rounded-md"
-              data-dropdown="navbar-dropdown"
-              data-tippy-placement="bottom"
-            )
-              i.fas.fa-user-circle.fa-2x.text-gray-500
-          #navbar-dropdown.hidden.origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
-            .py-1.rounded-md.bg-white.shadow-xs
-              = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
-                | 会社切替
-              / TODO:リンクを@orgに書き換える
-              = link_to [@org], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
-                | 会社詳細
+          button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
+            type="button"
+            class="group h-full flex items-center px-4 text-left focus:outline-none focus:rounded-md"
+            data-dropdown="navbar-dropdown"
+          )
+            i.fas.fa-user-circle.fa-2x.text-gray-500
+          #navbar-dropdown.hidden
+            .origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
+              .py-1.rounded-md.bg-white.shadow-xs
+                = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
+                  | 会社切替
+                / TODO:リンクを@orgに書き換える
+                = link_to [@org], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
+                  | 会社詳細

--- a/app/components/layout/navbar_component.html.slim
+++ b/app/components/layout/navbar_component.html.slim
@@ -19,9 +19,14 @@ nav.bg-white.shadow-sm
             path[stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"]
         .ml-3.relative
           div
-            button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out[aria-label="User menu" aria-haspopup="true"]
+            button#user-menu.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
+              type="button"
+              class="group h-full flex items-center px-4 text-left focus:outline-none focus:rounded-md"
+              data-dropdown="navbar-dropdown"
+              data-tippy-placement="bottom"
+            )
               i.fas.fa-user-circle.fa-2x.text-gray-500
-          .origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
+          #navbar-dropdown.hidden.origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
             .py-1.rounded-md.bg-white.shadow-xs
               = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
                 | 会社切替

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,5 +1,9 @@
+require("turbolinks").start()
+
 import '../css/tailwind.css';
 // import 'core-js/stable'
 // import 'regenerator-runtime/runtime'
 
 import '@fortawesome/fontawesome-free/js/all'
+import '../src/js/application.js'
+

--- a/app/javascript/src/js/application.js
+++ b/app/javascript/src/js/application.js
@@ -1,0 +1,1 @@
+import './dropdown.js'

--- a/app/javascript/src/js/dropdown.js
+++ b/app/javascript/src/js/dropdown.js
@@ -1,0 +1,33 @@
+import tippy from 'tippy.js'
+import 'tippy.js/animations/perspective.css';
+
+document.addEventListener('turbolinks:load', init)
+
+function init () {
+  tippy('[data-dropdown]', {
+    content (ref) {
+      if (!ref.dataset.dropdownTemplate) {
+        const id = ref.getAttribute('data-dropdown')
+        const template = document.getElementById(id)
+        ref.dataset.dropdownTemplate = template.innerHTML
+        template.remove()
+      }
+      return ref.dataset.dropdownTemplate
+    },
+    trigger: 'click',
+    allowHTML: true,
+    interactive: true,
+    appendTo: () => document.body,
+    animation: 'perspective',
+    duration: 100,
+    placement: 'bottom-end',
+    offset: [0, 4],
+    onMount(instance) {
+      const autoFocusElement = instance.popper.querySelector('[autofocus]')
+      if (autoFocusElement) autoFocusElement.focus()
+
+      const event = new CustomEvent('dropdown:mount', { detail: { element: instance.popper } })
+      document.dispatchEvent(event)
+    }
+  })
+}

--- a/app/javascript/src/js/dropdown.js
+++ b/app/javascript/src/js/dropdown.js
@@ -20,14 +20,6 @@ function init () {
     appendTo: () => document.body,
     animation: 'perspective',
     duration: 100,
-    placement: 'bottom-end',
-    offset: [0, 4],
-    onMount(instance) {
-      const autoFocusElement = instance.popper.querySelector('[autofocus]')
-      if (autoFocusElement) autoFocusElement.focus()
-
-      const event = new CustomEvent('dropdown:mount', { detail: { element: instance.popper } })
-      document.dispatchEvent(event)
-    }
+    placement: 'bottom-end'
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -648,6 +653,14 @@
         "pretty-hrtime": "^1.0.3",
         "reduce-css-calc": "^2.1.6",
         "resolve": "^1.14.2"
+      }
+    },
+    "tippy.js": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.2.7.tgz",
+      "integrity": "sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==",
+      "requires": {
+        "@popperjs/core": "^2.4.4"
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.0",
     "@rails/webpacker": "5.2.1",
-    "tailwindcss": "^1.8.10"
+    "tailwindcss": "^1.8.10",
+    "tippy.js": "^6.2.7",
+    "turbolinks": "^5.2.0"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,11 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@popperjs/core@^2.4.4":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
+  integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==
+
 "@rails/webpacker@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.2.1.tgz#87cdbd4af2090ae2d74bdc51f6f04717d907c5b3"
@@ -7243,6 +7248,13 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tippy.js@^6.2.7:
+  version "6.2.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.2.7.tgz#62fb34eda23f7d78151ddca922b62818c1ab9869"
+  integrity sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==
+  dependencies:
+    "@popperjs/core" "^2.4.4"
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -7331,6 +7343,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
# 概要
右上のドロップダウンメニューが常に表示されているので、ユーザーアイコンをクリック後、ドロップダウンメニューが表示されるようにする。

|![image](https://user-images.githubusercontent.com/45095615/103458264-ad471400-4d49-11eb-9c1d-1f932024a159.png)|
|:--|

# 参考

### tailwind ui
https://tailwindui.com/components/application-ui/elements/dropdowns

### tippy.js

https://atomiks.github.io/tippyjs/v6/all-props/

https://on-ze.com/archives/7310

# ToDo内容

```Terminal
# npm
npm i tippy.js

# Yarn
yarn add tippy.js

yarn add turbolinks
```

```js:app/javascript/src/js/dropdown.js
import tippy from 'tippy.js'
import 'tippy.js/animations/perspective.css';

document.addEventListener('turbolinks:load', init)

function init () {
  tippy('[data-dropdown]', {
    content (ref) {
      if (!ref.dataset.dropdownTemplate) {
        const id = ref.getAttribute('data-dropdown')
        const template = document.getElementById(id)
        ref.dataset.dropdownTemplate = template.innerHTML
        template.remove()
      }
      return ref.dataset.dropdownTemplate
    },
    trigger: 'click',
    allowHTML: true,
    interactive: true,
    appendTo: () => document.body,
    animation: 'perspective',
    duration: 100,
    placement: 'bottom-end'
  })
}
```

```slim:app/components/layout/navbar_component.html.slim
button.flex.text-sm.border-2.border-transparent.rounded-full.focus:outline-none.focus:border-gray-300.transition.duration-150.ease-in-out(
  type="button"
  class="group h-full flex items-center px-4 text-left focus:outline-none focus:rounded-md"
  data-dropdown="navbar-dropdown"
)
  i.fas.fa-user-circle.fa-2x.text-gray-500
#navbar-dropdown.hidden
  .origin-top-right.absolute.right-0.mt-2.w-48.rounded-md.shadow-lg
    .py-1.rounded-md.bg-white.shadow-xs
      = link_to [:orgs], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
        | 会社切替
      / TODO:リンクを@orgに書き換える
      = link_to [@org], class: 'block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out' do
        | 会社詳細
```

# 動作確認
## 準備

```Terminal:Terminal
bin/rails s
```

```Terminal:Terminal
bin/webpack-dev-server
```

## 受入基準
- [ ] 画面右上のドロップダウンメニューが、ユーザーアイコンのクリック後、表示される

|![db48b1940ae84a018aa47c8312f8716c](https://user-images.githubusercontent.com/45095615/103473519-d2d12d80-4ddc-11eb-986c-795aa930b3b7.gif)|
|:--|

